### PR TITLE
add ability to clone data

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -4,6 +4,7 @@ namespace MDOE\ExternalModule;
 
 use ExternalModules\AbstractExternalModule;
 use REDCap;
+use Files;
 
 class ExternalModule extends AbstractExternalModule {
 
@@ -35,7 +36,7 @@ class ExternalModule extends AbstractExternalModule {
         echo '<script src="' . $this->getUrl($path) . '">;</script>';
     }
 
-    function moveEvent($source_event_id, $target_event_id, $record_id = NULL, $project_id = NULL, $form_names = NULL) {
+    function moveEvent($source_event_id, $target_event_id, $record_id = NULL, $project_id = NULL, $form_names = NULL, $delete_source_data = true) {
         $record_id = $record_id ?: ( ($this->framework->getRecordId()) ?: NULL ); // return in place of NULL causes errors
         $project_id = $project_id ?: ( ($this->framework->getProjectId()) ?: NULL );
         $record_pk = REDCap::getRecordIdField();
@@ -64,27 +65,76 @@ class ExternalModule extends AbstractExternalModule {
             'events' => $source_event_id
         ];
 
+        $field_list = ($fields) ? " AND d.field_name IN ('" . implode('\',\'', $fields) . "');" : ";";
+        $edocs_sql = "SELECT d.field_name, em.doc_id, em.stored_name, em.doc_name
+            FROM redcap_data d
+        INNER JOIN redcap_metadata m
+            ON
+            m.project_id = d.project_id
+            AND m.field_name = d.field_name
+            AND m.element_type = 'file'
+        INNER JOIN redcap_edocs_metadata em
+            ON em.doc_id = d.value
+        WHERE
+            d.project_id = " . $project_id . "
+            AND d.record = " . $record_id . "
+            AND d.event_id = " . $source_event_id .
+            $field_list;
+
+        // TODO: consider: em.element_validation_type == 'signature'
+
+        $edocs_fields = $this->framework->query($edocs_sql);
+
+        $edocs_present = ($edocs_fields->num_rows > 0);
+        if ($edocs_present) {
+            $edocs_results = $edocs_fields->fetch_all(MYSQLI_ASSOC);
+        }
+
         $new_data = [];
 
         // get record for selected event, swap source_event_id for target_event_id
         $old_data = REDCap::getData($get_data);
         $new_data[$record_id][$target_event_id] = $old_data[$record_id][$source_event_id];
 
-        $response = REDCap::saveData($project_id, 'array', $new_data, 'normal');
-        $log_message = "Migrated form(s) " . $form_names . " from event " . $source_event_id . " to " . $target_event_id;
 
-        // soft delete all data for each field
-        // document fields do not migrate or soft delete via saveData
-        array_walk_recursive($old_data[$record_id][$source_event_id], function(&$value, $key) {
-                if ($key !== $record_pk) {
-                    $value = NULL;
+        if ($delete_source_data) {
+            $response = REDCap::saveData($project_id, 'array', $new_data, 'normal'); // initial write to target
+            $log_message = "Migrated form(s) " . $form_names . " from event " . $source_event_id . " to " . $target_event_id;
+
+            // soft delete all data for each field
+            array_walk_recursive($old_data[$record_id][$source_event_id], function(&$value, $key) {
+                    if ($key !== $record_pk) {
+                        $value = NULL;
+                    }
+                }
+            );
+            $delete_response = REDCap::saveData($project_id, 'array', $old_data, 'overwrite');
+
+            // previous step did not delete documents, force their migration
+            $log_message = $this->forceMigrateSourceFields($get_data, $project_id, $record_id, $source_event_id, $target_event_id, $log_message);
+        } else {
+            // Create copies of edocs for cloning
+            // necessary as if a cloned form containing an edoc is deleted, the file which all clones reference is also purged
+            if ($edocs_present) {
+                // Clone files and assign them to their respective fields in the cloned forms
+                foreach($edocs_results as $edocs_result) {
+                    if (isset($new_data[$record_id][$target_event_id][$edocs_result['field_name']])) {
+                        $path = Files::copyEdocToTemp($edocs_result['doc_id']); // clone the existing file to temp dir
+                        $file = [];
+                        $file['name'] = basename($edocs_result['doc_name']);
+                        $file['tmp_name'] = $path;
+                        $file['size'] = filesize($path);
+
+                        $new_data[$record_id][$target_event_id][$edocs_result['field_name']] =
+                            Files::uploadFile($file, $project_id);
+                    }
                 }
             }
-        );
-
-        $delete_response = REDCap::saveData($project_id, 'array', $old_data, 'overwrite');
-
-        $log_message = $this->forceMigrateSourceFields($get_data, $project_id, $record_id, $source_event_id, $target_event_id, $log_message);
+            $response = REDCap::saveData($project_id, 'array', $new_data, 'normal',
+                    'YMD', 'flat', null, true, true, true, false, true, array(), false,
+                    false); // do not skip file upload fields, see the REDCap core code Classes/Records.php
+            $log_message = "Cloned form(s) " . $form_names . " from event " . $source_event_id . " to " . $target_event_id;
+        }
 
         REDCap::logEvent("Moved data from an event to a different event", $log_message);
 
@@ -103,7 +153,7 @@ class ExternalModule extends AbstractExternalModule {
         foreach ($check_old as $field => $value) {
             if ($value !== '' && $value !== '0' && $value !== NULL &&
                 $field != REDCap::getRecordIdField()) {
-		        array_push($revisit_fields, "'$field'");
+                    array_push($revisit_fields, "'$field'");
             }
         }
 

--- a/js/mdoe.js
+++ b/js/mdoe.js
@@ -96,8 +96,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 const targetEventId = $(this).find('select').find(':selected').val();
                 ajaxMoveEvent(sourceEventId, targetEventId, formNames, true);
             },
-            Cancel: function() {
-              $(this).dialog( "close" );
+            "Clone Event Data": function() {
+                const targetEventId = $(this).find('select').find(':selected').val();
+                ajaxMoveEvent(sourceEventId, targetEventId, formNames, false);
             }
           },
         });
@@ -146,11 +147,12 @@ document.addEventListener('DOMContentLoaded', function() {
           buttons: {
             "Migrate Form Data": function() {
                 const targetEventId = $(this).find('select').find(':selected').val();
-                ajaxMoveEvent(params.get('event_id'), targetEventId, [params.get('page')]);
+                ajaxMoveEvent(params.get('event_id'), targetEventId, [params.get('page')], true);
                 // TODO: check that previous worked before deleting
             },
-            Cancel: function() {
-              $(this).dialog( "close" );
+            "Clone Form Data": function() {
+                const targetEventId = $(this).find('select').find(':selected').val();
+                ajaxMoveEvent(params.get('event_id'), targetEventId, [params.get('page')], false);
             }
           },
         });
@@ -171,7 +173,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
-function ajaxMoveEvent(sourceEventId, targetEventId, formNames = null, deleteEvent = false) {
+function ajaxMoveEvent(sourceEventId, targetEventId, formNames = null, deleteSourceData = false) {
     const searchParams = new URLSearchParams(window.location.search);
 
     $.get({
@@ -182,7 +184,8 @@ function ajaxMoveEvent(sourceEventId, targetEventId, formNames = null, deleteEve
                 targetEventId: targetEventId,
                 formNames: formNames,
                 recordId: searchParams.get('id'),
-                projectId: searchParams.get('pid')
+                projectId: searchParams.get('pid'),
+                deleteSourceData: deleteSourceData
               },
         })
     .done(function(data) {
@@ -190,11 +193,13 @@ function ajaxMoveEvent(sourceEventId, targetEventId, formNames = null, deleteEve
                 // TODO: parse and report errors
                 return 0;
             }
-            console.log(data);
-            if (deleteEvent) {
-                doDeleteEventInstance(sourceEventId); // reloads page on completion
-            } else {
-                location.reload();
-            }
+            location.reload();
+
+            // TODO: consider re-enabling this if targeting an event and the migration was successfull
+            //if (deleteSourceData /* && entireEvent */) {
+            //    doDeleteEventInstance(sourceEventId); // reloads page on completion
+            //} else {
+            //    location.reload();
+            //}
         });
 }

--- a/migratedata.php
+++ b/migratedata.php
@@ -9,12 +9,14 @@ $source_event_id = $_REQUEST["sourceEventId"];
 $target_event_id = $_REQUEST["targetEventId"];
 $record_id = $_REQUEST["recordId"];
 $project_id = $_REQUEST["projectId"];
+$delete_source_data = $_REQUEST["deleteSourceData"];
 
 $EM = new ExternalModule();
 
+//TODO: eliminate this switch
 switch ($migrating) {
     case 'event':
-        $response = $EM->moveEvent($source_event_id, $target_event_id, $record_id, $project_id, $form_names);
+        $response = $EM->moveEvent($source_event_id, $target_event_id, $record_id, $project_id, $form_names, $delete_source_data == "true");
         break;
     case 'field':
         echo "not implemented";


### PR DESCRIPTION
Adds ability to clone data from a form or event to another event.

In the provided project XML, record 1 contains a `.pdf` file in the **Participant Morale Questionnaire** form for events **Week 2** and **Week 3**.

New logic for handling files has been introduced; the following scenarios should be tested:  
1. A single form or entire event containing  one or more files is migrated
  - Ensure that each file is accessible in the target location
2. A single form or entire event containing  one or more files is cloned
  - Ensure that each file is accessible in both the target and source locations
  - Delete one of the event or single form clones and ensure that each file is still accessible in the remaining location(s)

[Events_2019-10-31_1214.REDCap.xml.zip](https://github.com/ctsit/move_data_to_other_event/files/3794814/Events_2019-10-31_1214.REDCap.xml.zip)

This PR will clash with PR #6 due to both making changes to the dialog UI. This PR should be considered first and the UI changes can be adjusted to fit this new functionality.