### PR TITLE
allow actions involving first form first event

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -102,7 +102,7 @@ class ExternalModule extends AbstractExternalModule {
             $log_message = "Migrated form(s) " . $form_names . " from event " . $source_event_id . " to " . $target_event_id;
 
             // soft delete all data for each field
-            array_walk_recursive($old_data[$record_id][$source_event_id], function(&$value, $key) {
+            array_walk_recursive($old_data[$record_id][$source_event_id], function(&$value, $key) use ($record_pk) {
                     if ($key !== $record_pk) {
                         $value = NULL;
                     }

--- a/js/mdoe.js
+++ b/js/mdoe.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function() {
             eDialogButton.clone().appendTo(eventColumn);
             });
 
-    $.each(formLinks.slice(1), function(i, link) {
+    $.each(formLinks, function(i, link) {
             try {
             const im = link.firstChild.src;
             // TODO: endsWith(array)


### PR DESCRIPTION
Addresses issue #8 and reintroduces the ability to move/clone data from the first form of the first event. 

See issue #8 for a project XML to test with.

Test:
1. Add new record
2. Save data on the first form of the **final** event
3. Migrate data from first form of final event to first form of **first** event

The icon for the final event in Record Status Dashboard should 

Caveats:  
After conducting the above process, accessing the first form on the final event you will see the **E-mail address** field appears filled. This is not caused by the module, it is an oddity of REDCap itself. Inspecting the `redcap_data` table in the database will reveal there is, in fact, no data left in the final event. This anomaly acts as one may expect if auto_populate_fields were active.

Using REDCap v9.4.1 (and possibly others) causes the user to be sent to the project home page after moving data. This is due to the `record cache` feature in REDCap core (take note of the GET parameter in the URL). This makes testing annoying, but does not affect the functioning of the module.